### PR TITLE
Add per-card wrapper template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 .coverage
 .coverage.*
 .cache
+
+painter/templates/custom/*.html

--- a/painter/models.py
+++ b/painter/models.py
@@ -10,3 +10,8 @@ class Card(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_template(self):
+        if self.template_name.startswith('custom/'):
+            return self.template_name
+        return 'custom/' + self.template_name

--- a/painter/templates/custom/__init__.py
+++ b/painter/templates/custom/__init__.py
@@ -1,0 +1,1 @@
+# Put all your custom templates in this directory!

--- a/painter/templates/painter/card_display.html
+++ b/painter/templates/painter/card_display.html
@@ -1,7 +1,7 @@
 <html>
 <body>
-<p>
-{{ object_list }}
-</p>
+{% for object in object_list %}
+    {% include 'painter/card_wrapper.html' %}
+{% endfor %}
 </body>
 </html>

--- a/painter/templates/painter/card_wrapper.html
+++ b/painter/templates/painter/card_wrapper.html
@@ -1,0 +1,3 @@
+<div class='card_wrapper'>
+    {% include object.template_name with c=object.data name=object.name %}
+</div>

--- a/painter/tests/test_models.py
+++ b/painter/tests/test_models.py
@@ -24,3 +24,15 @@ class TestCard(TestCase):
         name = 'Leeroy Jenkins'
         card = factories.CardFactory.create(name=name)
         self.assertEqual(str(card), name)
+
+    def test_get_template(self):
+        """The method returns the template name if it has "custom/" already."""
+        template_name = 'custom/leeroy.html'
+        card = factories.CardFactory.create(template_name=template_name)
+        self.assertEqual(card.get_template(), template_name)
+
+    def test_get_template_adjustment(self):
+        """The method returns the template name with "custom/" added if necessary."""
+        template_name = 'leeroy.html'
+        card = factories.CardFactory.create(template_name=template_name)
+        self.assertEqual(card.get_template(), 'custom/' + template_name)


### PR DESCRIPTION
The template for the card view looks like:

Main page template
- Card wrapper
  - Card template (custom)
- Card wrapper
  - Card template (custom)

The card wrapper needs to look up and include the card's stated `template_name` and pass in the card's `data` as a top-level object with an abbreviated name, `c` (so that the extending template can use a very simple `{{ c.cost }}`, `{{ c.attack }}` etc).
