### PR TITLE
Add main page template

### DIFF
--- a/painter/static/styles/layout.css
+++ b/painter/static/styles/layout.css
@@ -1,4 +1,11 @@
+/* layout.css - Lays out cards so they're the right size, have borders, etc.
+
+    User hooks:
+       .full-card - Sizes something to fit an entire card.  Useful for background <div>s.
+*/
+
 body {
+    /* Let's use a generic, concise, easily-readable font. */
     font-family: "Arial";
 }
 

--- a/painter/static/styles/layout.css
+++ b/painter/static/styles/layout.css
@@ -1,0 +1,42 @@
+body {
+    font-family: "Arial";
+}
+
+.spoiler {
+    /* The full card table. */
+    padding: 0px;
+    border-spacing: 2px solid gray;
+    background-color: gray;
+}
+
+.card-cell {
+    /* Apply a thick black border around each card to aid visually and with
+       cutting out sheets of printed cards. */
+    border: 0.9em solid black;
+    vertical-align: top;
+    position: relative;
+    background-color: #fff;
+}
+
+.card-cell, .card-wrapper, .full-card {
+    /* Fix the sizes of all card-sized things and ensure they're unpadded. */
+    width: 18.3em;
+    height: 26.2em;
+    padding: 0px;
+    margin: 0px;
+}
+
+.card-wrapper, .full-card {
+    /* Fix the positions of card-wrapping <div>s to ensure the objects inside them don't
+       push the card out of place or break the formatting. */
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    display: block;
+    overflow: hidden;
+}
+
+.card-wrapper * {
+    /* Non-explicit margins are going to get in the way and mess with formatting. */
+    margin: 0px;
+}

--- a/painter/static/styles/layout.css
+++ b/painter/static/styles/layout.css
@@ -10,7 +10,8 @@ body {
 }
 
 .spoiler {
-    /* The full card table. */
+    /* The full card table.  Displays a thin grey line between cards as a guideline
+       for cutting and as a visual separator. */
     padding: 0px;
     border-spacing: 2px solid gray;
     background-color: gray;

--- a/painter/templates/painter/card_display.html
+++ b/painter/templates/painter/card_display.html
@@ -1,7 +1,21 @@
+<!DOCTYPE html>
 <html>
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css">
+    <style>
+        // Modify Browserstack's behaviour a wee bit
+        @grid-gutter-width: 10px;
+    </style>
+</head>
+
 <body>
-{% for object in object_list %}
-    {% include 'painter/card_wrapper.html' %}
-{% endfor %}
+    <div class="container">
+        {% for object in object_list %}
+            <div id="card-{{ forloop.counter }}" class="col-lg-4">
+                {% include 'painter/card_wrapper.html' %}
+            </div>
+        {% endfor %}
+    </div>
 </body>
 </html>

--- a/painter/templates/painter/card_display.html
+++ b/painter/templates/painter/card_display.html
@@ -1,21 +1,25 @@
+{% load staticfiles %}
+
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css">
-    <style>
-        // Modify Browserstack's behaviour a wee bit
-        @grid-gutter-width: 10px;
-    </style>
+    <link rel="stylesheet" href="{% static "styles/layout.css" %}">
 </head>
 
 <body>
-    <div class="container">
-        {% for object in object_list %}
-            <div id="card-{{ forloop.counter }}" class="col-lg-4">
-                {% include 'painter/card_wrapper.html' %}
-            </div>
-        {% endfor %}
-    </div>
+    <table class="spoiler">
+        <tr>
+            {% for object in object_list %}
+                <td id="card-{{ forloop.counter }}" class="card-cell">
+                    {% include 'painter/card_wrapper.html' %}
+                </td>
+
+                {% if forloop.counter|divisibleby:3 %}
+                    </tr>
+                    <tr>
+                {% endif %}
+            {% endfor %}
+        </tr>
+    </table>
 </body>
 </html>

--- a/painter/templates/painter/card_wrapper.html
+++ b/painter/templates/painter/card_wrapper.html
@@ -1,3 +1,3 @@
 <div class='card_wrapper'>
-    {% include object.template_name with c=object.data name=object.name %}
+    {% include object.get_template with c=object.data name=object.name %}
 </div>

--- a/painter/templates/painter/card_wrapper.html
+++ b/painter/templates/painter/card_wrapper.html
@@ -1,3 +1,3 @@
-<div class='card_wrapper'>
+<div class="card-wrapper">
     {% include object.get_template with c=object.data name=object.name %}
 </div>


### PR DESCRIPTION
The main page template needs to lay out the cards in a visual-spoiler style, suitable for both printing and reading by eye.  Bootstrap ought to be a great way to get both the card visuals and the layout up and running quickly, and its column formatting tools will be invaluable, so let's use that.

The main page is also probably the right place to add thick black borders between each of the cards.  This is both visually pleasing and helps with cutting them out.
