### PR TITLE
Change how lists are generated from CSVs

### DIFF
--- a/painter/tests/test_import_cards.py
+++ b/painter/tests/test_import_cards.py
@@ -43,13 +43,11 @@ class TestImportCards(TestCase):
 
         self.assertEqual(cards['no_html_extension'].template_name, 'test.html')
 
-    def test_newline_forms_lists_everywhere(self):
+    def test_list_columns(self):
         """
-        A column containing at least one entry with a newline in it is considered to have
-        a list type, so everything in that column is converted into a list, separated
-        by the newlines.
+        A column whose name begins with an asterisk is turned into a list.
         """
-        csv_data = 'name,template,Card Rules\n'
+        csv_data = 'name,template,*Card Rules\n'
         csv_data += 'non_newlined_rules,test,one_line\n'
         csv_data += 'newlined_rules,test,"new\nline"\n'
         csv_data += 'empty_rules,test,\n'


### PR DESCRIPTION
The current newline approach works reasonably, but is a bit awkward.  If your items all happen to be singletons, Painter will get it wrong and you'll end up with a string being treated as a list in your template.  So:
- A column that's meant to be a list should have its name preceded by an asterisk.  So `*Special Rules`, for example.  This means the column will be treated as a list column regardless of its contents.  Newline is still the separator.
- Columns containing newlines are not automatically transformed into lists.
- A column with alternative separator characters can be defined like this: `*[...]Special Rules`, with any number of separator characters inside the square brackets.  If the closing square bracket is missing, the leading `*[` is ignored and the rest of the string is treated as the name of the column.
